### PR TITLE
error functionality in simple_shell added

### DIFF
--- a/_error.c
+++ b/_error.c
@@ -1,0 +1,96 @@
+#include "shell.h"
+
+/**
+ * _putchar - function that prints a single character
+ * @c: character to print
+ * Return: always 1
+ */
+int _putchar(char c)
+{
+	return (write(1, &c, 1));
+}
+
+
+/**
+ * _puts - Prints a string character by character.
+ * @str: String to be printed. If the string is NULL it will print (null)
+ *
+ * Return: Nothing
+ */
+void _puts(char *str)
+{
+	int i;
+
+	if (str == NULL)
+		str = "(null)";
+	for (i = 0; str[i] != '\0'; i++)
+		_putchar(str[i]);
+}
+
+
+/**
+ * _print_number - function that prints an integer
+ * to standard output
+ * @n: number to be printed
+ *
+ * Return: count of numbers printed
+ */
+int _print_number(int n)
+{
+	int div = 1;
+	int count;
+	unsigned int num;
+
+	div = 1;
+	count = 0;
+
+	num = n;
+
+	while (num / div > 9)
+		div *= 10;
+
+	while (div != 0)
+	{
+		count += _write_char('0' + num / div);
+		num %= div;
+		div /= 10;
+	}
+
+	return (count);
+}
+
+
+/**
+ * _print_error - function that prints error message if the
+ * executable command is not found
+ * @cmd: executable command
+ * @counter: command counter
+ * @argv: argument vector
+ *
+ * Return: nothing
+ */
+void _print_error(char *argv, int counter, char *command)
+{
+	_puts(argv);
+	_puts(": ");
+	_print_number(counter);
+	_puts(": ");
+	_puts(command);
+}
+
+/**
+ * _error_execve - function that prints error message if
+ * execve() fails
+ * @cmd: executable command
+ * @counter: command counter
+ * @argv: argument vector
+ *
+ * Return: nothing
+ */
+void _error_execve(char *argv, int counter, char *cmd)
+{
+	_print_error(argv, counter, cmd);
+	_puts(": ");
+	perror("");
+	exit(1);
+}

--- a/_error.c
+++ b/_error.c
@@ -51,7 +51,7 @@ int _print_number(int n)
 
 	while (div != 0)
 	{
-		count += _write_char('0' + num / div);
+		count += _putchar('0' + num / div);
 		num %= div;
 		div /= 10;
 	}

--- a/_execve.c
+++ b/_execve.c
@@ -45,7 +45,7 @@ void _execve(char **linecmd, char *lineptr, int counter, char **argv)
 		if (linecmd[0] != NULL)
 		{
 			if (execve(linecmd[0], linecmd, environ) == -1)
-				perror("argv[0]");
+				_error_execve(argv[0], counter, cmd);
 		}
 	}
 	else

--- a/_execve.c
+++ b/_execve.c
@@ -17,8 +17,6 @@ void _execve(char **linecmd, char *lineptr, int counter, char **argv)
 	int stat_check;
 	pid_t pid = fork();
 
-	(void)argv;
-	(void)counter;
 
 	if (pid == 0)
 	{

--- a/_execve.c
+++ b/_execve.c
@@ -29,7 +29,9 @@ void _execve(char **linecmd, char *lineptr, int counter, char **argv)
 			stat_check = stat(cmd, &buf);
 			if (stat_check == -1)
 			{
-				perror("Stat Error");
+				_print_error(argv[0], counter, cmd);
+				_puts(": not found");
+				_putchar('\n');
 				free(lineptr);
 				free(cmd);
 				for (i = 1; linecmd[i] != NULL; i++)

--- a/shell.h
+++ b/shell.h
@@ -46,7 +46,11 @@ char **_pathtokens(char *str);
 char *_exec_path(char **tokens, char *cmd);
 char *_build_path(char *e_path, char *cmd);
 char *_getpath(char *cmd);
-
+int _putchar(char c);
+void _puts(char *str);
+int _print_number(int n);
+void _error_execve(char *argv, int counter, char *cmd);
+void _print_error(char *argv, int counter, char *command);
 
 
 


### PR DESCRIPTION
Hello Soumia!

This functions takes care of errors similar to /bin/sh.
prints error message when the executable command/file cannot be found in the path specified in bin and also when execve function fails

Kindly review it